### PR TITLE
docs(api): 음성 기반 일정 등록 API 문서화

### DIFF
--- a/src/modules/schedules/dto/voice-schedule.dto.ts
+++ b/src/modules/schedules/dto/voice-schedule.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CreateScheduleDto } from './create-schedule.dto';
+
+export class VoiceScheduleUploadDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'binary',
+    description: '음성 파일 (.wav, .mp3 등)',
+  })
+  audio: any;
+
+  @ApiProperty({
+    example: '2024-09-13 12:45:50',
+    description: '음성 인식 시점의 현재 날짜와 시간',
+  })
+  currentDateTime: string;
+}
+
+export class VoiceScheduleConfirmDto extends CreateScheduleDto {
+  @ApiProperty({ example: '노인부 찬양 집회 참석', description: '일정 의도' })
+  intent: string;
+}

--- a/src/modules/schedules/schedules.service.ts
+++ b/src/modules/schedules/schedules.service.ts
@@ -13,6 +13,7 @@ import { DateRangeDto } from './dto/data-range-schedule.dto';
 import { MonthQueryDto } from './dto/month-query-schedule.dto';
 import { WeekQueryDto } from './dto/week-query-schedule.dto';
 import { plainToInstance } from 'class-transformer';
+import { VoiceScheduleConfirmDto } from './dto/voice-schedule.dto';
 
 @Injectable()
 export class SchedulesService {
@@ -153,5 +154,24 @@ export class SchedulesService {
     });
 
     return schedules.map((schedule) => new ScheduleResponseDto(schedule));
+  }
+
+  async processVoiceSchedule(
+    audioBuffer: Buffer,
+    currentDateTime: string,
+  ): Promise<VoiceScheduleConfirmDto[]> {
+    return [];
+  }
+
+  async confirmAndSaveSchedule(
+    scheduleData: VoiceScheduleConfirmDto[],
+  ): Promise<ScheduleResponseDto[]> {
+    return scheduleData.map(
+      (data) =>
+        new ScheduleResponseDto({
+          scheduleId: 0, // 임시 ID
+          ...data,
+        } as Schedule),
+    );
   }
 }


### PR DESCRIPTION
## ✅ ISSUE 번호
#13
## ✅ 작업 내용
- 음성 파일 업로드 및 일정 추출 엔드포인트 추가 (/schedules/upload)
- 추출된 일정 확인 및 저장 엔드포인트 추가 (/schedules/confirm)
- VoiceScheduleUploadDto 및 VoiceScheduleConfirmDto 정의
- SchedulesController에 음성 기반 일정 등록 메소드 추가
- SchedulesService의 음성기반 서비스는 아직 미구현 상태

## ✅ 리뷰 요청사항
API 엔드포인트 설계의 적절성
각 엔드포인트에 대한 설명, 파라미터, 응답 형식이 충분히 상세하고 명확한지 검토 부탁
