### PR TITLE
feat: 스케줄 기본값 및 Swagger 연동 업데이트

### DIFF
--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -20,9 +20,10 @@ export const dataSourceOptions: DataSourceOptions & SeederOptions = {
   entities: [Auth, User, Category, Schedule],
   migrations: [resolve(__dirname, 'migrations', '*.{js,ts}')],
   seeds: [CategorySeeder],
-  ssl: {
-    rejectUnauthorized: false,
-  },
+  ssl:
+    process.env.NODE_ENV === 'production'
+      ? { rejectUnauthorized: false }
+      : false,
   extra: {
     timezone: '+09:00',
   },

--- a/src/entities/schedule.entity.ts
+++ b/src/entities/schedule.entity.ts
@@ -8,8 +8,8 @@ export class Schedule {
   @Column({ name: 'user_id' })
   userId: number;
 
-  @Column({ name: 'category_id' })
-  categoryId: number;
+  @Column({ name: 'category_id', default: 7 })
+  categoryId?: number;
 
   @Column({ name: 'start_date', type: 'timestamp' })
   startDate: Date;
@@ -17,8 +17,8 @@ export class Schedule {
   @Column({ name: 'end_date', type: 'timestamp' })
   endDate: Date;
 
-  @Column({ length: 255 })
-  title: string;
+  @Column({ length: 255, default: '새로운 일정' })
+  title?: string;
 
   @Column({ length: 255, default: '' })
   place?: string;

--- a/src/modules/schedules/dto/create-schedule.dto.ts
+++ b/src/modules/schedules/dto/create-schedule.dto.ts
@@ -16,11 +16,17 @@ export class CreateScheduleDto {
   @IsNumber()
   userId: number;
 
-  @ApiProperty({ description: '카테고리 ID', example: 2 })
-  @IsNotEmpty()
+  @ApiProperty({
+    description: '카테고리 ID',
+    example: 2,
+    default: 7,
+    required: false,
+  })
+  @IsOptional()
   @Type(() => Number)
   @IsNumber()
-  categoryId: number;
+  @Transform(({ value }) => value || 7) // 기본값 설정
+  categoryId?: number;
 
   @ApiProperty({
     description: '일정 시작 날짜',
@@ -44,13 +50,19 @@ export class CreateScheduleDto {
     description: '일정 제목',
     example: '마을 잔치',
     default: '새로운 이벤트',
+    required: false,
   })
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   @Transform(({ value }) => value || '새로운 이벤트') // 기본값 설정
-  title: string;
+  title?: string;
 
-  @ApiProperty({ description: '장소', example: '노인정', default: '' })
+  @ApiProperty({
+    description: '장소',
+    example: '노인정',
+    default: '',
+    required: false,
+  })
   @IsOptional()
   @IsString()
   @Transform(({ value }) => value || '') // 기본값 설정
@@ -67,13 +79,17 @@ export class CreateScheduleDto {
   @Transform(({ value }) => value || '') // 기본값 설정
   memo?: string;
 
-  @ApiProperty({ description: '그룹 일정 여부', default: false })
+  @ApiProperty({
+    description: '그룹 일정 여부',
+    default: false,
+    required: false,
+  })
   @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => (value !== undefined ? value : false)) // 기본값 설정
   isGroupSchedule?: boolean;
 
-  @ApiProperty({ description: '종일 옵션', default: false })
+  @ApiProperty({ description: '종일 옵션', default: false, required: false })
   @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => (value !== undefined ? value : false)) // 기본값 설정

--- a/src/modules/schedules/dto/response-schedule.dto.ts
+++ b/src/modules/schedules/dto/response-schedule.dto.ts
@@ -1,13 +1,71 @@
+import { PickType } from '@nestjs/mapped-types';
 import { ApiProperty } from '@nestjs/swagger';
 import { CreateScheduleDto } from './create-schedule.dto';
 import { Schedule } from 'src/entities/schedule.entity';
 
-export class ScheduleResponseDto extends CreateScheduleDto {
+export class ResponseScheduleDto extends PickType(CreateScheduleDto, [
+  'userId',
+  'categoryId',
+  'startDate',
+  'endDate',
+  'title',
+  'place',
+  'memo',
+  'isGroupSchedule',
+  'isAllDay',
+] as const) {
   @ApiProperty({ description: '일정 ID', example: 1 })
   scheduleId: number;
 
+  @ApiProperty({ description: '사용자 ID', example: 1, required: true })
+  userId: number;
+
+  @ApiProperty({ description: '카테고리 ID', example: 2, required: true })
+  categoryId: number;
+
+  @ApiProperty({
+    description: '일정 시작 날짜',
+    example: '2024-09-21T09:00:00Z',
+    required: true,
+  })
+  startDate: Date;
+
+  @ApiProperty({
+    description: '일정 종료 날짜',
+    example: '2024-09-21T18:00:00Z',
+    required: true,
+  })
+  endDate: Date;
+
+  @ApiProperty({
+    description: '일정 제목',
+    example: '마을 잔치',
+    required: true,
+  })
+  title: string;
+
+  @ApiProperty({ description: '장소', example: '노인정', required: true })
+  place: string;
+
+  @ApiProperty({
+    description: '메모',
+    example: '이장님 몰래하는거라 조심해서 해야한다.',
+    required: true,
+  })
+  memo: string;
+
+  @ApiProperty({
+    description: '그룹 일정 여부',
+    example: false,
+    required: true,
+  })
+  isGroupSchedule: boolean;
+
+  @ApiProperty({ description: '종일 옵션', example: false, required: true })
+  isAllDay: boolean;
+
   constructor(schedule: Schedule) {
-    super(); // 상위 클래스의 속성 초기화
+    super();
     this.scheduleId = schedule.scheduleId;
     this.userId = schedule.userId;
     this.categoryId = schedule.categoryId;

--- a/src/modules/schedules/schedules.controller.ts
+++ b/src/modules/schedules/schedules.controller.ts
@@ -21,7 +21,7 @@ import {
 import { CreateScheduleDto } from './dto/create-schedule.dto';
 import { SchedulesService } from './schedules.service';
 import { UpdateScheduleDto } from './dto/update-schedule.dto';
-import { ScheduleResponseDto } from './dto/response-schedule.dto';
+import { ResponseScheduleDto } from './dto/response-schedule.dto';
 import { DateRangeDto } from './dto/data-range-schedule.dto';
 import { MonthQueryDto } from './dto/month-query-schedule.dto';
 import { WeekQueryDto } from './dto/week-query-schedule.dto';
@@ -43,12 +43,12 @@ export class SchedulesController {
   @ApiResponse({
     status: 200,
     description: '일정 조회 성공',
-    type: [ScheduleResponseDto],
+    type: [ResponseScheduleDto],
   })
   async getSchedulesByDateRange(
     @Query('userId') userId: number,
     @Query() dateRange: DateRangeDto,
-  ): Promise<ScheduleResponseDto[]> {
+  ): Promise<ResponseScheduleDto[]> {
     return this.schedulesService.findByDateRange(userId, dateRange);
   }
 
@@ -60,15 +60,15 @@ export class SchedulesController {
   @ApiResponse({
     status: 201,
     description: '일정이 성공적으로 생성됨',
-    type: ScheduleResponseDto,
+    type: ResponseScheduleDto,
   })
   @ApiResponse({ status: 400, description: '잘못된 입력' })
   @ApiResponse({ status: 401, description: '인증 실패' })
   async createSchedule(
     @Body() createScheduleDto: CreateScheduleDto,
-  ): Promise<ScheduleResponseDto> {
+  ): Promise<ResponseScheduleDto> {
     const schedule = await this.schedulesService.create(createScheduleDto);
-    return new ScheduleResponseDto(schedule);
+    return new ResponseScheduleDto(schedule);
   }
 
   @Patch(':id')
@@ -79,7 +79,7 @@ export class SchedulesController {
   @ApiResponse({
     status: 200,
     description: '일정이 성공적으로 업데이트됨',
-    type: ScheduleResponseDto,
+    type: ResponseScheduleDto,
   })
   @ApiResponse({ status: 400, description: '잘못된 입력' })
   @ApiResponse({ status: 401, description: '인증 실패' })
@@ -87,9 +87,9 @@ export class SchedulesController {
   async updateSchedule(
     @Param('id') id: number,
     @Body() updateScheduleDto: UpdateScheduleDto,
-  ): Promise<ScheduleResponseDto> {
+  ): Promise<ResponseScheduleDto> {
     const schedule = await this.schedulesService.update(id, updateScheduleDto);
-    return new ScheduleResponseDto(schedule);
+    return new ResponseScheduleDto(schedule);
   }
 
   @Delete(':id')
@@ -109,11 +109,11 @@ export class SchedulesController {
   @ApiResponse({
     status: 200,
     description: '일정 조회 성공',
-    type: [ScheduleResponseDto],
+    type: [ResponseScheduleDto],
   })
   async getSchedulesByWeek(
     @Query() weekQuery: WeekQueryDto,
-  ): Promise<ScheduleResponseDto[]> {
+  ): Promise<ResponseScheduleDto[]> {
     console.log('getSchedulesByWeek called with:', weekQuery);
     return this.schedulesService.findByWeek(weekQuery);
   }
@@ -123,11 +123,11 @@ export class SchedulesController {
   @ApiResponse({
     status: 200,
     description: '일정 조회 성공',
-    type: [ScheduleResponseDto],
+    type: [ResponseScheduleDto],
   })
   async getSchedulesByMonth(
     @Query() monthQuery: MonthQueryDto,
-  ): Promise<ScheduleResponseDto[]> {
+  ): Promise<ResponseScheduleDto[]> {
     console.log('getSchedulesByMonth called with:', monthQuery);
     return this.schedulesService.findByMonth(monthQuery);
   }
@@ -140,13 +140,13 @@ export class SchedulesController {
   @ApiResponse({
     status: 200,
     description: '일정 조회 성공',
-    type: ScheduleResponseDto,
+    type: ResponseScheduleDto,
   })
   @ApiResponse({ status: 401, description: '인증 실패' })
   @ApiResponse({ status: 404, description: '일정을 찾을 수 없음' })
-  async getScheduleById(@Param('id') id: number): Promise<ScheduleResponseDto> {
+  async getScheduleById(@Param('id') id: number): Promise<ResponseScheduleDto> {
     const schedule = await this.schedulesService.findOne(id);
-    return new ScheduleResponseDto(schedule);
+    return new ResponseScheduleDto(schedule);
   }
 
   @Get()
@@ -155,11 +155,11 @@ export class SchedulesController {
   @ApiResponse({
     status: 200,
     description: '일정 조회 성공',
-    type: [ScheduleResponseDto],
+    type: [ResponseScheduleDto],
   })
   async getAllSchedulesByUserId(
     @Query('userId') userId: number,
-  ): Promise<ScheduleResponseDto[]> {
+  ): Promise<ResponseScheduleDto[]> {
     return this.schedulesService.findAllByUserId(userId);
   }
 
@@ -189,7 +189,7 @@ export class SchedulesController {
   @ApiResponse({
     status: 201,
     description: '저장된 일정 정보',
-    type: [ScheduleResponseDto],
+    type: [ResponseScheduleDto],
   })
   async confirmSchedule(@Body() scheduleData: VoiceScheduleConfirmDto[]) {
     return await this.schedulesService.confirmAndSaveSchedule(scheduleData);

--- a/src/modules/schedules/schedules.service.ts
+++ b/src/modules/schedules/schedules.service.ts
@@ -8,7 +8,7 @@ import { UpdateScheduleDto } from './dto/update-schedule.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Schedule } from '../../entities/schedule.entity';
 import { Between, Repository } from 'typeorm';
-import { ScheduleResponseDto } from './dto/response-schedule.dto';
+import { ResponseScheduleDto } from './dto/response-schedule.dto';
 import { DateRangeDto } from './dto/data-range-schedule.dto';
 import { MonthQueryDto } from './dto/month-query-schedule.dto';
 import { WeekQueryDto } from './dto/week-query-schedule.dto';
@@ -24,19 +24,19 @@ export class SchedulesService {
 
   async create(
     createScheduleDto: CreateScheduleDto,
-  ): Promise<ScheduleResponseDto> {
+  ): Promise<ResponseScheduleDto> {
     // 기본값을 넣어주는 용도 (일반 자바스크립트 객체를 클래스의 인스턴스로 변환, 클래스에 정의된 데코레이터와 기본값들이 적용)
     const scheduleData = plainToInstance(CreateScheduleDto, createScheduleDto);
 
     const newSchedule = this.schedulesRepository.create(scheduleData);
     const savedSchedule = await this.schedulesRepository.save(newSchedule);
-    return new ScheduleResponseDto(savedSchedule);
+    return new ResponseScheduleDto(savedSchedule);
   }
 
   async update(
     id: number,
     updateScheduleDto: UpdateScheduleDto,
-  ): Promise<ScheduleResponseDto> {
+  ): Promise<ResponseScheduleDto> {
     const schedule = await this.schedulesRepository.findOne({
       where: { scheduleId: id },
     });
@@ -50,7 +50,7 @@ export class SchedulesService {
     Object.assign(schedule, updateScheduleDto);
 
     const savedSchedule = await this.schedulesRepository.save(schedule);
-    return new ScheduleResponseDto(savedSchedule);
+    return new ResponseScheduleDto(savedSchedule);
   }
 
   async remove(id: number): Promise<void> {
@@ -62,7 +62,7 @@ export class SchedulesService {
     }
   }
 
-  async findOne(id: number): Promise<ScheduleResponseDto> {
+  async findOne(id: number): Promise<ResponseScheduleDto> {
     const schedule = await this.schedulesRepository.findOne({
       where: { scheduleId: id },
     });
@@ -71,22 +71,22 @@ export class SchedulesService {
         `해당 id : ${id}를 가진 스케쥴을 찾을 수 없습니다. `,
       );
     }
-    return new ScheduleResponseDto(schedule);
+    return new ResponseScheduleDto(schedule);
   }
 
-  async findAllByUserId(userId: number): Promise<ScheduleResponseDto[]> {
+  async findAllByUserId(userId: number): Promise<ResponseScheduleDto[]> {
     const schedules = await this.schedulesRepository.find({
       where: { userId: userId },
       order: { startDate: 'ASC' }, // 시작 날짜 기준 오름차순 정렬
     });
 
-    return schedules.map((schedule) => new ScheduleResponseDto(schedule));
+    return schedules.map((schedule) => new ResponseScheduleDto(schedule));
   }
 
   async findByDateRange(
     userId: number,
     dateRange: DateRangeDto,
-  ): Promise<ScheduleResponseDto[]> {
+  ): Promise<ResponseScheduleDto[]> {
     if (dateRange.startDate > dateRange.endDate) {
       throw new BadRequestException(
         '시작 날짜는 종료 날짜보다 늦을 수 없습니다.',
@@ -100,10 +100,10 @@ export class SchedulesService {
       order: { startDate: 'ASC' },
     });
 
-    return schedules.map((schedule) => new ScheduleResponseDto(schedule));
+    return schedules.map((schedule) => new ResponseScheduleDto(schedule));
   }
 
-  async findByMonth(monthQuery: MonthQueryDto): Promise<ScheduleResponseDto[]> {
+  async findByMonth(monthQuery: MonthQueryDto): Promise<ResponseScheduleDto[]> {
     console.log('findByMonth 호출 형식 :', monthQuery);
 
     const startDate = new Date(monthQuery.year, monthQuery.month - 1, 1);
@@ -121,10 +121,10 @@ export class SchedulesService {
 
     console.log('Schedules found:', schedules.length);
 
-    return schedules.map((schedule) => new ScheduleResponseDto(schedule));
+    return schedules.map((schedule) => new ResponseScheduleDto(schedule));
   }
 
-  async findByWeek(weekQuery: WeekQueryDto): Promise<ScheduleResponseDto[]> {
+  async findByWeek(weekQuery: WeekQueryDto): Promise<ResponseScheduleDto[]> {
     console.log('findByWeek called with:', weekQuery);
 
     const date = new Date(weekQuery.date);
@@ -159,7 +159,7 @@ export class SchedulesService {
 
     console.log('Schedules found:', schedules.length);
 
-    return schedules.map((schedule) => new ScheduleResponseDto(schedule));
+    return schedules.map((schedule) => new ResponseScheduleDto(schedule));
   }
 
   async processVoiceSchedule(
@@ -171,10 +171,10 @@ export class SchedulesService {
 
   async confirmAndSaveSchedule(
     scheduleData: VoiceScheduleConfirmDto[],
-  ): Promise<ScheduleResponseDto[]> {
+  ): Promise<ResponseScheduleDto[]> {
     return scheduleData.map(
       (data) =>
-        new ScheduleResponseDto({
+        new ResponseScheduleDto({
           scheduleId: 0, // 임시 ID
           ...data,
         } as Schedule),


### PR DESCRIPTION
## ✅ ISSUE 번호
#23 
## ✅ 작업 내용
- Schedule Entity: categoryId를 옵셔널로 설정하고 기본값을 '기타' (categoryId = 7)로 설정
- Schedule Entity: title을 옵셔널로 설정하고 기본값을 "새로운 일정"으로 설정
- CreateScheduleDto: categoryId를 옵셔널로 설정하고 기본값을 '기타' (categoryId = 7)로 설정
- CreateScheduleDto: title을 옵셔널로 설정하고 기본값을 "새로운 일정"으로 설정
- ScheduleResponseDto 이름을 ResponseScheduleDto로 변경
- ResponseScheduleDto: 모든 필드 필수 처리
- dataSource 파일의 production 환경에서만 SSL이 true가 되도록 설정 수정
- Swagger 문서와 코드가 일치하도록 DTO 관련 Swagger 문서 업데이트
