### PR TITLE
[FiX] 카테고리 아이디 대신 카테고리 객체 반환

### DIFF
--- a/src/modules/schedules/dto/voice-schedule.dto.ts
+++ b/src/modules/schedules/dto/voice-schedule.dto.ts
@@ -1,5 +1,7 @@
+import { Category } from '@/entities/category.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
+import { CreateScheduleDto } from './create-schedule.dto';
 
 export class VoiceScheduleUploadDto {
   @ApiProperty({
@@ -17,33 +19,12 @@ export class VoiceScheduleUploadDto {
   currentDateTime: Date;
 }
 
-export class VoiceScheduleResponseDto {
-  @ApiProperty({ description: '사용자 ID', example: 1 })
-  userId: number;
+export class VoiceScheduleResponseDto extends CreateScheduleDto {
+  @ApiProperty({ description: '카테고리 정보' })
+  category: Category;
 
-  @ApiProperty({
-    description: '일정 시작 날짜와 "시간"',
-    example: '2024-09-21T09:00:00Z',
-    type: Date,
-  })
-  startDate: Date;
-
-  @ApiProperty({
-    description: '일정 종료 날짜와 "시간"',
-    example: '2024-09-21T18:00:00Z',
-    type: Date,
-  })
-  endDate: Date;
-
-  @ApiProperty({ description: '일정 제목', example: '주일 예배' })
-  title: string;
-
-  @ApiProperty({ description: '장소', example: '동네 교회' })
-  place: string;
-
-  @ApiProperty({ description: '종일 옵션', example: false })
-  isAllDay: boolean;
-
-  @ApiProperty({ description: '카테고리 ID', example: 4 })
-  categoryId: number;
+  constructor(partial: Partial<VoiceScheduleResponseDto> = {}) {
+    super();
+    Object.assign(this, partial);
+  }
 }

--- a/src/modules/schedules/schedules.service.ts
+++ b/src/modules/schedules/schedules.service.ts
@@ -20,6 +20,7 @@ import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 import { Category } from '@/entities/category.entity';
 import * as jwt from 'jsonwebtoken';
+import { VoiceScheduleResponseDto } from './dto/voice-schedule.dto';
 
 @Injectable()
 export class SchedulesService {
@@ -434,19 +435,19 @@ export class SchedulesService {
 
   private async convertGptResponseToCreateDto(
     gptEvents: any[],
-  ): Promise<CreateScheduleDto[]> {
+  ): Promise<VoiceScheduleResponseDto[]> {
     // 모든 카테고리를 한 번에 조회
     const allCategories = await this.categoryRepository.find();
 
-    // 카테고리 이름을 키로, ID를 값으로 하는 맵 생성
+    // 카테고리 이름을 키로, 카테고리 객체를 값으로 하는 맵 생성
     const categoryMap = allCategories.reduce((acc, category) => {
-      acc[category.categoryName] = category.categoryId;
+      acc[category.categoryName] = category;
       return acc;
     }, {});
 
     return Promise.all(
       gptEvents.map(async (event) => {
-        const dto = new CreateScheduleDto();
+        const dto = new VoiceScheduleResponseDto();
         dto.userId = 1; // 임시 사용자 ID
         dto.startDate = new Date(event.startDate);
         dto.endDate = new Date(event.endDate);
@@ -455,7 +456,8 @@ export class SchedulesService {
         dto.isAllDay = event.isAllDay;
 
         // 카테고리 매핑
-        dto.categoryId = categoryMap[event.category] || categoryMap['기타'];
+        const category = categoryMap[event.category] || categoryMap['기타'];
+        dto.category = category; // 전체 카테고리 객체 설정
 
         console.log(dto);
         return dto;


### PR DESCRIPTION
## ✅ ISSUE 번호
#41 
## ✅ 작업 내용
        const category = categoryMap[event.category] || categoryMap['기타'];
        dto.category = category; // 전체 카테고리 객체 설정
로 설정하여 해당 이름을 가진 카테고리 객체(카테고리 아이디와 카테고리 네임) 을 반환하도록 함.
