### PR TITLE
[FIX] 스케줄 생성 시 카테고리 ID 기본값 설정 문제 해결

### DIFF
--- a/src/modules/schedules/schedules.service.ts
+++ b/src/modules/schedules/schedules.service.ts
@@ -59,7 +59,8 @@ export class SchedulesService {
   async create(
     createScheduleDto: CreateScheduleDto,
   ): Promise<ResponseScheduleDto> {
-    const category = await this.getCategoryById(createScheduleDto.categoryId);
+    const categoryId = createScheduleDto.categoryId ?? 7;
+    const category = await this.getCategoryById(categoryId);
 
     const newSchedule = this.schedulesRepository.create({
       ...createScheduleDto,


### PR DESCRIPTION
## ✅ ISSUE 번호
#49 
## ✅ 작업 내용
SchedulesService 수정:

create 메서드에서 const categoryId = createScheduleDto.categoryId ?? 7; 추가
getCategoryById 메서드 호출 시 위에서 설정한 categoryId 사용