### PR TITLE
관리자관련 엔티티 작성;

### DIFF
--- a/src/entities/manager-invitation.entity.ts
+++ b/src/entities/manager-invitation.entity.ts
@@ -1,0 +1,33 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+export enum InvitationStatus {
+  PENDING = 'PENDING',
+  ACCEPTED = 'ACCEPTED',
+  REJECTED = 'REJECTED',
+}
+
+@Entity('manager_invitation')
+export class ManagerInvitation {
+  @PrimaryGeneratedColumn({ name: 'manager_invitation_id' })
+  managerInvitationId: number;
+
+  @Column({ name: 'inviter_uuid', type: 'varchar' })
+  inviterUuid: string;
+
+  @Column({ name: 'invitee_uuid', type: 'varchar' })
+  inviteeUuid: string;
+
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: InvitationStatus,
+    default: InvitationStatus.PENDING,
+  })
+  status: InvitationStatus;
+
+  @Column({
+    name: 'expired_at',
+    type: 'timestamp',
+  })
+  expiredAt: Date;
+}

--- a/src/entities/manager-subordinate.entity.ts
+++ b/src/entities/manager-subordinate.entity.ts
@@ -1,0 +1,21 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity('manager-subordinate')
+export class ManagerSubordinate {
+  @PrimaryGeneratedColumn({ name: 'user_manager_id' })
+  userManagerId: number;
+
+  @Column({ type: 'varchar', name: 'manager_uuid' })
+  managerUuid: string;
+
+  @Column({ type: 'varchar', name: 'subordinate_uuid' })
+  subordinateUuid: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}


### PR DESCRIPTION
## ✅ ISSUE 번호
#53 
## ✅ 작업 내용
<img width="466" alt="image" src="https://github.com/user-attachments/assets/a872b5c5-b1f4-4e3c-ba14-82da53e0daed">
관리자 관련 엔티티를 생성하였습니다. 
초대를 보내고 [수락, 거절, 수신] 세 가지 상태를 가지며 30일 뒤에 해당 로그는 삭제됩니다.
또한 초대를 수락하게 되면 관리자 테이블에 레코드가 추가됩니다.
