### PR TITLE
[REFACTOR] 음성 스케줄 dto 변경

### DIFF
--- a/src/modules/schedules/dto/voice-schedule-upload.dto.ts
+++ b/src/modules/schedules/dto/voice-schedule-upload.dto.ts
@@ -1,8 +1,5 @@
-import { Category } from '@/entities/category.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { CreateScheduleDto } from './create-schedule.dto';
-
 export class VoiceScheduleUploadDto {
   @ApiProperty({
     type: 'file',
@@ -17,14 +14,4 @@ export class VoiceScheduleUploadDto {
   })
   @Type(() => Date)
   currentDateTime: Date;
-}
-
-export class VoiceScheduleResponseDto extends CreateScheduleDto {
-  @ApiProperty({ description: '카테고리 정보' })
-  category: Category;
-
-  constructor(partial: Partial<VoiceScheduleResponseDto> = {}) {
-    super();
-    Object.assign(this, partial);
-  }
 }


### PR DESCRIPTION
## ✅ ISSUE 번호
#127 
## ✅ 작업 내용

기존 음성 스케줄에서 DTO에서 카테고리를 이중으로 처리하고 있다.
즉,voiceScheduleDto에서 createScheduleDto를 확장으로 카테고리 객체를 선언하다 보니 해당 문제가 발생됨.

 voiceScheduleDto를 없애고 createScheduleDto만 처리
 기존 모델 출력 title과 intent로 반환되더라도 처리할 수 있도록 변경
 스웨거 업데이트
